### PR TITLE
ci(snap): publish when trigger manually on citadel branch

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -36,7 +36,7 @@ jobs:
         path: ${{ steps.build-snap.outputs.snap }}
 
   publish:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/citadel')
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
Sometimes, we don't need to push changes but still need to republish a new snap (when a dependency has received a security update)