### PR TITLE
fix(gz-rendering): use new directory name

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -195,7 +195,7 @@ parts:
       sed -i "s|OGRE2_RESOURCE_PATH|\"/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/OGRE-2.1/OGRE\"|" gz-rendering/ogre2/src/Ogre2RenderEngine.cc
       sed -i "s|OGRE_RESOURCE_PATH|\"/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/OGRE-1.9.0\"|" gz-rendering/ogre/src/OgreRenderEngine.cc
       sed -i "s|@IGN_SENSORS_PLUGIN_PATH@|/snap/$SNAPCRAFT_PROJECT_NAME/current/opt/ros/snap/lib|" gz-sensors/include/ignition/sensors/config.hh.in
-      sed -i 's|\${IGNITION_RENDERING_ENGINE_INSTALL_DIR}|/snap/$SNAPCRAFT_PROJECT_NAME/current/opt/ros/snap/lib/ign-rendering-3/engine-plugins|' gz-rendering/include/ignition/rendering/config.hh.in
+      sed -i 's|\${IGNITION_RENDERING_ENGINE_INSTALL_DIR}|/snap/$SNAPCRAFT_PROJECT_NAME/current/opt/ros/snap/lib/ign-rendering-3/engine-plugins|' gz-rendering/include/gz/rendering/config.hh.in
 
       # artificial ign package.xml are not "installed" so rosdep try to redownload them
       sed -i 's|<depend>ignition-plugin<\/depend>|<build_depend>ignition-plugin1<\/build_depend>|' ign_ros2_control/ign_ros2_control/package.xml


### PR DESCRIPTION
Gazebo is continuing its name migration from `ignition/ign` to `gazebo/gz`. Here the source files of `ign-rendering-3` changed from the `ign` subdirectory to the `gz` subdirectory 