### PR TITLE
Feat/valid optimisation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Project and community
+More than ten years ago, ROS started with Ubuntu. Our responsibility and commitment to this community will keep growing. 
+Canonical's robotics team is your team. We value your input and contributions!
+
+You can get involved by:
+
++ **Reporting bugs**: we want to know about the problems so we can fix them.
++ **Quality assurance**: before releasing new features we make a “Call for Testing” a week prior to each update reaching “stable”. This is your opportunity to discover and report any problems.
++ **Documentation**: there are lots of ways to use Snaps and Ubuntu Core for robotics applications. We try to describe the important ones, but maybe we missed yours.
++ **Feature requests**: we have a lot of ideas on what to do next but you know what you need.
++ **Code changes**: the code is open and we are open to accepting changes to it. So, don’t worry about maintaining a new fork, and instead, let’s work together.
+
+Robotics in Ubuntu will continue growing with our community. If you want to get involved:
+
++ Join the [Discourse community forum](https://forum.snapcraft.io/)
++ Read our [Code of Conduct](https://ubuntu.com/community/code-of-conduct?_ga=2.257795469.700127210.1669067579-38830517.1655463002)
++ Report a bug or contribute on [Github](https://github.com/ubuntu-robotics)
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -236,6 +236,25 @@ parts:
       done
       ####
 
+      #### remove unnecessary files
+      # remove every header and source file
+      fdfind --type file --type symlink '.*\.(hpp|hxx|h|hh|cpp|cxx|c|cc)$' $SNAPCRAFT_PRIME  --exec rm {}
+      # remove every cmake file
+      fdfind --type file --type symlink '(.cmake|CMakeLists.txt)$' $SNAPCRAFT_PRIME  --exec rm {}
+      # remove every example(s) directories
+      fdfind --type directory "^examples?$" $SNAPCRAFT_PRIME --exec rm -rf {}
+      # remove man files
+      rm -rf $SNAPCRAFT_PRIME/usr/share/man
+      # remove doc files
+      rm -rf $SNAPCRAFT_PRIME/usr/share/doc
+      # remove perl share files
+      rm -rf $SNAPCRAFT_PRIME/usr/share/perl
+      # remove /usr/src/
+      rm -rf $SNAPCRAFT_PRIME/usr/src
+      # remove additional sources
+      rm -rf $SNAPCRAFT_PRIME/opt/ros/foxy/src/
+      ####
+
 apps:
 
   # We're not creating the `gazebo` app just yet has this could conflict

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -219,6 +219,23 @@ parts:
     organize:
       'fastdds_no_shared_memory.xml': usr/share/
 
+  cleanup:
+    after: [gazebo, ros2-foxy-extension]
+    plugin: nil
+    build-packages: [fd-find] # installing fd-find and run it once is usually faster than calling find once
+    override-prime: |
+      #### remove content sharing snap duplicate
+      KDE_CONTENT_SNAP=$(echo $SNAPCRAFT_CMAKE_ARGS | sed -n 's/.*\/snap\/\(.*\)-sdk.*/\1/p')
+      # remove duplicated files available in content snap
+      for snap in "core20" $KDE_CONTENT_SNAP; do  # list all content-snaps and base snaps you're using here
+          snap install $snap
+          # we don't delete symlink
+          cd "/snap/$snap/current/" && fdfind . --type f --exec rm -f "$SNAPCRAFT_PRIME/{}" \;
+          # we delete symlink pointing to nowhere
+          find "$SNAPCRAFT_PRIME" -xtype l -delete
+      done
+      ####
+
 apps:
 
   # We're not creating the `gazebo` app just yet has this could conflict

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -255,6 +255,39 @@ parts:
       rm -rf $SNAPCRAFT_PRIME/opt/ros/foxy/src/
       ####
 
+      #### remove unnecessary debian packages
+      function remove-apt-package () {
+        # because of the previous cleanup, we might have deleted headers that were installed by Debian packages, hence we ignore listing a file that no longer exist
+        set +o pipefail
+        $(dpkg -L $1 | xargs -I {} bash -c 'ls -ld $SNAPCRAFT_PRIME{} 2> /dev/null || true' | grep -v "^d" | awk '{print $NF}' | xargs rm -f)
+        # remove empty directories
+        $(dpkg -L $1 | xargs -I {} bash -c 'ls -ld $SNAPCRAFT_PRIME{} 2> /dev/null || true' | grep "^d" | tail -n +2 | awk '{print $NF}' | xargs -I {} rmdir --ignore-fail-on-non-empty {})
+        set -o pipefail
+      }
+
+      function remove-apt-package-with-prefix () {
+        for pkg in $(dpkg --get-selections "$1*" | awk '{print $1}')
+        do
+          remove-apt-package $pkg
+        done
+      }
+
+      remove-apt-package ros-foxy-rosidl-adapter
+      remove-apt-package ros-foxy-rosidl-generator-c
+      remove-apt-package ros-foxy-rosidl-generator-cpp
+      remove-apt-package ros-foxy-rosidl-generator-py
+      remove-apt-package ros-foxy-ament-cmake-gmock
+      remove-apt-package ros-foxy-python-cmake-module
+      remove-apt-package python3-pytest
+
+      # remove globs of packages
+      remove-apt-package-with-prefix ros-foxy-ament-cmake
+      remove-apt-package-with-prefix ros-foxy-testing
+      remove-apt-package-with-prefix python3-colcon
+      remove-apt-package-with-prefix python3-rosdep
+      remove-apt-package-with-prefix cmake
+      ####
+
 apps:
 
   # We're not creating the `gazebo` app just yet has this could conflict


### PR DESCRIPTION
Bring optimisations to the Gazebo snap.
The optimisations concern the size of the snap as well as the size of the installation in `/snap/gazebo/current`.

The following optimisations have been done:
- Remove every file already present in a content sharing
- Remove unnecessary files (headers, sources, cmake files, examples, man files, perl doc)
- Remove unnecessary Debian packages only necessary at build-time

This results in the snap being 48% smaller and taking 44% less space on the disk once installed.