### PR TITLE
Feat/fix ci

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -16,6 +16,7 @@ jobs:
     secrets:
       snapstore-login: ${{ secrets.STORE_LOGIN }}
     with:
+      snapcraft-channel: '7.x/stable'
       runs-on: '[["self-hosted", "linux", "X64", "xlarge", "jammy"]]'
       snap-track: fortress
       snap-test-script: |

--- a/snap/local/override_pull.sh
+++ b/snap/local/override_pull.sh
@@ -4,12 +4,11 @@
       vcs import < ros2-ign.yaml
 
       # delete the directory since we don't want rosdep to pull the deps
+      rm -rf ign_ros2_control/gz_ros2_control_demos
+      rm -rf ign_ros2_control/gz_ros2_control_tests
       rm -rf ign_ros2_control/ign_ros2_control_demos
-
-      # delete the directory since we don't want rosdep to pull the deps
-      rm -rf ros_gz/ros_ign_gazebo_demos ros_gz/ros_gz_sim_demos
-      # temporary, it depends on some odds version of ign libs, https://github.com/gazebosim/ros_gz/issues/40
-      rm -rf ros_gz/ros_ign_point_cloud ros_gz/ros_gz_point_cloud
+      rm -rf ros_gz/ros_gz_sim_demos
+      rm -rf ros_gz/ros_ign_gazebo_demos
 
       # you can use fake_package_xml_generator to prepare a draft for gz_packages_XML based on the output of vcs import
       # python3 scripts/fake_package_generator.py [folder_where_vcs_imported_gz_repos]
@@ -22,7 +21,7 @@
 
       # artificial ign package.xml are not "installed" so rosdep try to redownload them
       sed -i 's|<depend>ignition-plugin<\/depend>|<build_depend>ignition-plugin1<\/build_depend>|' ign_ros2_control/ign_ros2_control/package.xml
-      sed -i '/ignition-.*<\/depend/s/depend/build_depend/g' ign_ros2_control/ign_ros2_control/package.xml
+      sed -i '/ignition-.*<\/depend/s/depend/build_depend/g' ign_ros2_control/gz_ros2_control/package.xml
       find ros_gz -name package.xml -exec sed -i '/ignition-.*<\/depend/s/depend/build_depend/g' {} \;
 
       sed -i '/ros_ign_gazebo_demos/d' ros_gz/ros_ign/package.xml


### PR DESCRIPTION
Fix the gazebo fortress build.

It stopped building due to :
- packages getting moved to ROS 2 repo
- packages and repo renamed from ign to gz prefix

Additionally, building with snapcraft 8 was causing issues.
It seems that the kde-neon extensions got a big update in order to support qt6.

The complete error message when launching gz is: https://pastebin.canonical.com/p/vMPkTMThzX/
with the specific error being:
```
libGL error: DRI driver not from this Mesa build ('23.2.1-1ubuntu3.1~22.04.2' vs '23.2.1-1ubuntu3.1~22.04.3')
libGL error: failed to load driver: iris
```
Related links found:
- https://bugs.launchpad.net/ubuntu/+source/mesa/+bug/2054827
- https://forum.snapcraft.io/t/snap-run-libegl-fatal-dri-driver-not-from-this-mesa-build-24-0-5-1ubuntu1-vs-24-0-9-0ubuntu0-1/40975

Also, I noted that [the KDE neon project is no longer using the `kde-neon` extension from snapcraft](https://invent.kde.org/packaging/snapcraft-kde-applications/-/blob/Neon/release/okular/snapcraft.yaml?ref_type=heads#L11)

The content sharing kde snaps changed of name from `kf5-5-105-qt-5-15-9-core22-all` to `kf5-core22-sdk`.

Switching back to snapcraft 7 fixed the issue for Gazebo.
